### PR TITLE
PW-209: Fix all final toasts on account page

### DIFF
--- a/app/(website)/account/[tab]/Commenting.tsx
+++ b/app/(website)/account/[tab]/Commenting.tsx
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from "react";
 import Button from "@/components/ui/Button";
 import styles from "@/styles/pages/account.module.scss";
 
-import LoadingOverlay from "./LoadingOverlay";
 import {Toast, ToastUtil, ToastableError} from "@/components/ui/Toast";
 
 export const Commenting = ({updateCommentsDisplayName, updateCommentsNotifications, profile}) => {
@@ -22,9 +21,7 @@ export const Commenting = ({updateCommentsDisplayName, updateCommentsNotificatio
   }, [isLoading]);
 
   useEffect(() => {
-
     if (error) {
-
       ToastUtil.showErrorToast(error);
     }
   }, [error]);
@@ -82,9 +79,11 @@ export const Commenting = ({updateCommentsDisplayName, updateCommentsNotificatio
     const newNotification = event.target.checked;
 
     setIsLoading(true);
+    setSuccessMsg("");
     await updateCommentsNotifications(newNotification);
     setNotification(newNotification);
     setIsLoading(false);
+    setSuccessMsg("Comment notifications updated");
   };
 
   return (

--- a/app/(website)/account/[tab]/EmailPreferences.tsx
+++ b/app/(website)/account/[tab]/EmailPreferences.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import {useState, useEffect} from "react";
-
 import {Toast, ToastUtil, ToastableError} from "@/components/ui/Toast";
-
-import LoadingOverlay from "./LoadingOverlay";
 
 const EmailPreferences = ({user}) => {
   const [selectedNewsLetters, setSelectedNewsLetters] = useState<String[]>([]);
@@ -49,6 +46,14 @@ const EmailPreferences = ({user}) => {
       ToastUtil.dismissToast();
     }
   }, [isProgress]);
+
+  useEffect(() => {
+    if (isLoading > 1) {
+      ToastUtil.showLoadingToast();
+    } else {
+      ToastUtil.dismissToast();
+    }
+  }, [isLoading]);
 
   useEffect(() => {
     if (successMsg) {
@@ -103,11 +108,6 @@ const EmailPreferences = ({user}) => {
 
   return (
     <>
-      {/* Display Loading or Progress Indicators */}
-      {!!isLoading && (
-        <LoadingOverlay message="Loading Newsletter Preferences..." />
-      )}
-
       <p>Subscribe or unsubscribe to our newsletters</p>
       <div className={`checkboxRow`}>
         <label>

--- a/app/(website)/account/[tab]/MyDetails.tsx
+++ b/app/(website)/account/[tab]/MyDetails.tsx
@@ -9,7 +9,6 @@ import { set } from "sanity";
 export const MyDetails = ({ userDetails, setUserName }) => {
   const [lastUpdatedName, setLastUpdatedName] = useState(userDetails?.full_name ?? "");
   const [lastUpdatedEmail, setLastUpdatedEmail] = useState(userDetails?.email ?? "");
-  const [detailUpdateMsg, setDetailUpdateMsg] = useState("");
   const [successMsg, setSuccessMsg] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<ToastableError | null>(null);
@@ -36,7 +35,6 @@ export const MyDetails = ({ userDetails, setUserName }) => {
 
   const handleSubmitName = async event => {
     event.preventDefault();
-    setDetailUpdateMsg("");
     setSuccessMsg("");
     setIsLoading(true);
 
@@ -44,7 +42,6 @@ export const MyDetails = ({ userDetails, setUserName }) => {
       const formData = new FormData(event.target);
       const newName = formData.get("name") as string;
       if (newName === lastUpdatedName) {
-        setDetailUpdateMsg(`Different name required`);
         setIsLoading(false);
         return;
       }
@@ -69,15 +66,10 @@ export const MyDetails = ({ userDetails, setUserName }) => {
 
       setUserName(updatedName);
       setLastUpdatedName(updatedName);
-      setDetailUpdateMsg(`User name updated successfully`);
-      setTimeout(() => {
-        setDetailUpdateMsg("");
-      }, 3000);
       setIsLoading(false);
       setSuccessMsg("Successfully updated user name");
     } catch (error) {
       console.error(`Error updating name: ${error.message}`);
-      setDetailUpdateMsg(error.message);
       setIsLoading(false);
       setError(error);
     }
@@ -85,7 +77,6 @@ export const MyDetails = ({ userDetails, setUserName }) => {
 
   const handleSubmitEmail = async event => {
     event.preventDefault();
-    setDetailUpdateMsg("");
     setSuccessMsg("");
     setIsLoading(true);
 
@@ -93,7 +84,6 @@ export const MyDetails = ({ userDetails, setUserName }) => {
       const formData = new FormData(event.target);
       const newEmail = formData.get("email") as string;
       if (newEmail === lastUpdatedEmail) {
-        setDetailUpdateMsg(`Different email required`);
         setIsLoading(false);
         return;
       }
@@ -112,12 +102,10 @@ export const MyDetails = ({ userDetails, setUserName }) => {
       }
 
       setLastUpdatedEmail(newEmail);
-      setDetailUpdateMsg(`User email updated successfully`);
       setIsLoading(false);
       setSuccessMsg("Successfully updated user email");
     } catch (error) {
       console.error(`Error updating email: ${error.message}`);
-      setDetailUpdateMsg(error.message);
       setIsLoading(false);
       setError(error);
     }
@@ -125,7 +113,6 @@ export const MyDetails = ({ userDetails, setUserName }) => {
 
   return (
     <>
-      {!!detailUpdateMsg && <h2 className={styles.tag}>{detailUpdateMsg}</h2>}
       <div className={styles.infoGroup}>
         <form id="nameForm" onSubmit={handleSubmitName}>
           <label>Full name</label>

--- a/app/(website)/subscribe/[step]/Payment.tsx
+++ b/app/(website)/subscribe/[step]/Payment.tsx
@@ -74,7 +74,6 @@ const Payment: React.FC<PaymentProps> = ({ email, subscription }) => {
   return (
     <>
       <SubscriptionPlan />
-      {isLoading && <div>Loading...</div>}
       {subscription ? (
         <>
           <h1>You have already subscribed</h1>

--- a/components/ui/Toast/Toast.tsx
+++ b/components/ui/Toast/Toast.tsx
@@ -68,6 +68,7 @@ export default function Toast() {
                     draggable
                     pauseOnHover
                     theme="dark"
+                    limit={1}
             />
         </div>
     );

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -1226,8 +1226,8 @@ footer {
     align-items: flex-start;
   }
   .disclaimer {
-    position: absolute;
-    bottom: 20px;
+    position: relative;
+    margin-top: 10px;
     align-self: center;
     a {
       text-decoration: underline rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
#209.
Fixes a handful of minor bugs mentioned by @jaredhwlt wrt toast behavior on the account page. Namely:

1. Shows loading toast initially on account page load
2. Shows success toast when commenting tab check selection is made
3. Removes all extraneous LoadingOverlay text on name and email change
4. Fixes styling issue on payment (step-3) of subscribe flow (where terms disclaimer gets cuts off)
